### PR TITLE
Ouvre l'accès à la vue Artois

### DIFF
--- a/public_website/templates/public_website/pole_emploi_status.html
+++ b/public_website/templates/public_website/pole_emploi_status.html
@@ -11,10 +11,15 @@
                 {% csrf_token %}
                 
                 <div class="fr-col-12 fr-col-sm-6">
-                    <label class="fr-label" for="identifiant_pole_emploi">{{ form.identifiant_pole_emploi.label }}</label>
-                    <input class="fr-input" type="text" id="identifiant_pole_emploi" name="identifiant_pole_emploi" value="{{ form.data.identifiant_pole_emploi }}">
-                    <input type="submit" value="Rechercher">
+                    <div class="fr-search-bar fr-search-bar--lg" role="search">
+                    <label class="fr-label" for="identifiant_pole_emploi">
+                        {{ form.identifiant_pole_emploi.label }}
+                    </label>
+                    <input class="fr-input" placeholder="Rechercher" type="search" id="identifiant_pole_emploi" name="identifiant_pole_emploi" value="{{ form.data.identifiant_pole_emploi }}">
+                    <input class="fr-btn" type="submit" value="Rechercher">
+                    </div>
                 </div>
+                
             </form>
 
             <div class="fr-col-12 fr-mt-4w">

--- a/public_website/tests.py
+++ b/public_website/tests.py
@@ -49,17 +49,17 @@ class TestServicesPage(TestCase):
         match = resolve("/artois-mobilites/")
         self.assertEqual(match.func, views.pole_emploi_status_view)
 
-    def test_reaching_artoismobilites_without_login_returns_redirect(self):
-        response = self.client.get("/artois-mobilites/")
-        self.assertEqual(response.status_code, 302)
-        self.assertRedirects(response, "/login/")
+    # def test_reaching_artoismobilites_without_login_returns_redirect(self):
+    #     response = self.client.get("/artois-mobilites/")
+    #     self.assertEqual(response.status_code, 302)
+    #     self.assertRedirects(response, "/login/")
 
-    def test_reaching_artoismobilites_without_login_returns_error_message(self):
-        response = self.client.get("/artois-mobilites/", follow=True)
-        self.assertEqual(response.status_code, 200)
-        self.assertRedirects(response, "/login/")
-        expected_message = "Vous devez être connecté·e pour accéder à cette page"
-        self.assertContains(response, expected_message)
+    # def test_reaching_artoismobilites_without_login_returns_error_message(self):
+    #     response = self.client.get("/artois-mobilites/", follow=True)
+    #     self.assertEqual(response.status_code, 200)
+    #     self.assertRedirects(response, "/login/")
+    #     expected_message = "Vous devez être connecté·e pour accéder à cette page"
+    #     self.assertContains(response, expected_message)
 
     def test_logged_in_user_can_reach_artoismobilites(self):
         self.client.force_login(self.testuser)

--- a/public_website/views.py
+++ b/public_website/views.py
@@ -27,8 +27,8 @@ def login_view(request):
     return render(request, "public_website/login.html", {})
 
 
-@login_required_message()
-@authorization_required_message(group_name="Artois Mobilités")
+# @login_required_message()
+# @authorization_required_message(group_name="Artois Mobilités")
 def pole_emploi_status_view(request):
     inscription_data = None
     form = InscritPoleEmploiForm


### PR DESCRIPTION
# Objectif 

Permettre à nos partenaires d'Artois Mobilités et de Transdev de tester l'interface sans qu'iels n'aient à se créer de compte.